### PR TITLE
stream.request(id, seq); and onRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,12 @@ it easy to represent what messages have not been seen using just a incrementing 
 
 ## todo
 
-* progress signals about how replicated we are (whether we are in sync or not, etc)
 * call a user function to decide whether we want to replicate a given feed (say, for blocking bad pers)
 * handle models where it's okay to have gaps in a log (as with classic [insecure scuttlebutt](https://github.com/dominictarr/scuttlebutt)
 
 ## License
 
 MIT
+
 
 

--- a/example.js
+++ b/example.js
@@ -31,7 +31,6 @@ function createStream(chat) {
 
 
   var stream = createEbtStream(
-    vectorClock,
     //pass a get(id, seq, cb)
     function (id, seq, cb) {
       if(!chat.logs[id] || !chat.logs[id][seq-1])
@@ -43,7 +42,9 @@ function createStream(chat) {
       chat.append(msg)
       cb()
     }
-  )
+  ) ({
+    seqs: vectorClock,
+  })
 
   chat.onAppend(stream.onAppend)
 
@@ -72,5 +73,7 @@ if(!module.parent) {
 
 exports.createChatModel = createChatModel
 exports.createStream = createStream
+
+
 
 

--- a/index.js
+++ b/index.js
@@ -43,162 +43,171 @@ function toEnd(err) {
   return err === true ? null : err
 }
 
-module.exports = function (seqs, get, append, onChange, callback) {
+//get, append are tied to the protocol
+//seqs, onChange, onRequest, callback are tied to the instance.
+module.exports = function (get, append) {
 
-  var readyMsg = [], readyNote = {}
-  onChange = onChange || require('./bounce')(function () {
-    console.log(progress(states))
-  }, 1000)
+  return function (opts, callback) {
+    if('function' === typeof opts)
+      callback = opts, opts = {}
 
-  //called if this feed is has not been requested
-  function onRequest (id, seq) {
-    stream.request(id, 0)
-  }
+    var readyMsg = [], readyNote = {}
+    onChange = opts.onChange || require('./bounce')(function () {
+      console.log(progress(states))
+    }, 1000)
 
-  function maybeQueue(key, state) {
-    if('string' !== typeof key) throw new Error('key should be string')
-    if('object' !== typeof state)
-      throw new Error('state should be object')
-
-    if(isMessage(state.ready))
-      readyMsg.push(state)
-    else if(isNote(state.ready))
-      readyNote[key] = true
-  }
-
-  var states = {}, error
-
-  var next = Next()
-  function checkNote (k) {
-    if(isNote(states[k].effect)) {
-      get(k, states[k].effect, function (err, msg) {
-        if(msg) {
-          maybeQueue(k, states[k] = S.gotMessage(states[k], msg))
-          if(states[k].ready) next()
-        }
-      })
+    //called if this feed is has not been requested
+    var onRequest = opts.onRequest || function (id, seq) {
+      stream.request(id, 0)
     }
-  }
 
-  var stream = {
-    sink: function (read) {
-      read(null, function cb (err, data) {
-        //handle errors and aborts
-        if(err && !error) { //if this sink got an error before source was aborted.
-          callback(toEnd(error = err))
-        }
-        if(error) return read(error, function () {})
+    function maybeQueue(key, state) {
+      if('string' !== typeof key) throw new Error('key should be string')
+      if('object' !== typeof state)
+        throw new Error('state should be object')
 
-        if(isMessage(data)) {
-          if(!states[data.author]) throw new Error('received strange author')
-          maybeQueue(data.author, states[data.author] = S.receiveMessage(states[data.author], data))
-          if(isMessage(states[data.author].effect)) {//append this message
-            states[data.author].effect = null
-            // *** append MUST call onAppend before the callback ***
-            //for performance, append should verify + queue the append, but not write to database.
-            //also note, there may be other messages which have been received
-            //and we could theirfore do parallel calls to append, but would make this
-            //code quite complex.
-            append(data, function (err) {
-              onChange()
-              read(null, cb)
-              next()
-            })
+      if(isMessage(state.ready))
+        readyMsg.push(state)
+      else if(isNote(state.ready))
+        readyNote[key] = true
+    }
+
+    var states = {}, error
+
+    var next = Next()
+    function checkNote (k) {
+      if(isNote(states[k].effect)) {
+        get(k, states[k].effect, function (err, msg) {
+          if(msg) {
+            maybeQueue(k, states[k] = S.gotMessage(states[k], msg))
+            if(states[k].ready) next()
           }
-          else
-            read(null, cb)
-
-          next()
-        }
-        else {
-          var ready = false
-
-          for(var k in data) {
-            //if we havn't requested this yet, see if we want it.
-            //if we _don't want it_ we should say, otherwise
-            //they'll ask us again next time.
-            if(!states[k]) onRequest(k, data[k])
-
-            maybeQueue(k, states[k] = S.receiveNote(states[k], data[k]))
-            if(states[k].ready != null)
-              ready = true
-            checkNote(k)
-          }
-
-          if(ready) next()
-          onChange()
-          read(null, cb)
-        }
-      })
-    },
-    source: function (abort, cb) {
-      //if there are any states with a message to send, take the oldest one.
-      //else, collect all states with a note, and send as a bundle.
-      //handle errors and aborts
-      if(abort) {
-        if(!error) //if the source was aborted before the sink got an error
-          return callback(toEnd(error = abort))
-        else
-          error = abort
+        })
       }
-      ;(function read () {
-        //this happens when the client 
-        if(error) return cb(error)
+    }
 
-        var state
-        if(readyMsg.length && (state = oldest(readyMsg)) && isMessage(state.ready)) {
-          var msg = state.ready
-          maybeQueue(msg.author, state = S.read(state))
-          checkNote(msg.author)
-          onChange()
-          cb(null, msg)
-        }
-        else {
-          var notes = {}, n = 0
+    var stream = {
+      sink: function (read) {
+        read(null, function cb (err, data) {
+          //handle errors and aborts
+          if(err && !error) { //if this sink got an error before source was aborted.
+            callback(toEnd(error = err))
+          }
+          if(error) return read(error, function () {})
 
-          for(k in readyNote) {
-            if(isNote(states[k].ready)) {
-              n ++
-              notes[k] = states[k].ready
-              states[k] = S.read(states[k])
+          if(isMessage(data)) {
+            if(!states[data.author]) throw new Error('received strange author')
+            maybeQueue(data.author, states[data.author] = S.receiveMessage(states[data.author], data))
+            if(isMessage(states[data.author].effect)) {//append this message
+              states[data.author].effect = null
+              // *** append MUST call onAppend before the callback ***
+              //for performance, append should verify + queue the append, but not write to database.
+              //also note, there may be other messages which have been received
+              //and we could theirfore do parallel calls to append, but would make this
+              //code quite complex.
+              append(data, function (err) {
+                onChange()
+                read(null, cb)
+                next()
+              })
+            }
+            else
+              read(null, cb)
+
+            next()
+          }
+          else {
+            var ready = false
+
+            for(var k in data) {
+              //if we havn't requested this yet, see if we want it.
+              //if we _don't want it_ we should say, otherwise
+              //they'll ask us again next time.
+              if(!states[k]) onRequest(k, data[k])
+
+              maybeQueue(k, states[k] = S.receiveNote(states[k], data[k]))
+              if(states[k].ready != null)
+                ready = true
               checkNote(k)
             }
+
+            if(ready) next()
+            onChange()
+            read(null, cb)
           }
-
-          readyNote = {}
-
-          onChange()
-          if(n) cb(null, notes)
-          else next(read)
+        })
+      },
+      source: function (abort, cb) {
+        //if there are any states with a message to send, take the oldest one.
+        //else, collect all states with a note, and send as a bundle.
+        //handle errors and aborts
+        if(abort) {
+          if(!error) //if the source was aborted before the sink got an error
+            return callback(toEnd(error = abort))
+          else
+            error = abort
         }
-      })()
-    },
-    progress: function () {
-      return progress(states)
-    },
-    onAppend: function (msg) {
-      var k = msg.author
-      //TMP, call a user provided function to decide how to handle this.
-      if(!states[k]) maybeQueue(k, states[k] = S.init(msg.sequence))
-      if(states[k]) {
-        maybeQueue(k, states[k] = S.appendMessage(states[k], msg))
-        checkNote(k)
-        next()
-      }
-    },
-    request: function (id, seq) {
-      if(!states[id]) {
-        states[id] = S.init(seq)
-        readyNote[id] = true
-      }
+        ;(function read () {
+          //this happens when the client 
+          if(error) return cb(error)
+
+          var state
+          if(readyMsg.length && (state = oldest(readyMsg)) && isMessage(state.ready)) {
+            var msg = state.ready
+            maybeQueue(msg.author, state = S.read(state))
+            checkNote(msg.author)
+            onChange()
+            cb(null, msg)
+          }
+          else {
+            var notes = {}, n = 0
+
+            for(k in readyNote) {
+              if(isNote(states[k].ready)) {
+                n ++
+                notes[k] = states[k].ready
+                states[k] = S.read(states[k])
+                checkNote(k)
+              }
+            }
+
+            readyNote = {}
+
+            onChange()
+            if(n) cb(null, notes)
+            else next(read)
+          }
+        })()
+      },
+      progress: function () {
+        return progress(states)
+      },
+      onAppend: function (msg) {
+        var k = msg.author
+        //TMP, call a user provided function to decide how to handle this.
+        if(!states[k]) maybeQueue(k, states[k] = S.init(msg.sequence))
+        if(states[k]) {
+          maybeQueue(k, states[k] = S.appendMessage(states[k], msg))
+          checkNote(k)
+          next()
+        }
+      },
+      request: function (id, seq) {
+        if(!states[id]) {
+          states[id] = S.init(seq)
+          readyNote[id] = true
+        }
+      },
+      states: states
     }
+
+    if(opts.seqs) {
+      for(var k in opts.seqs)
+        stream.request(k, opts.seqs[k])
+    }
+    return stream
+
   }
-
-  for(var k in seqs)
-    stream.request(k, seqs[k])
-
-  return stream
-
 }
 
 

--- a/test/stream.js
+++ b/test/stream.js
@@ -20,7 +20,6 @@ function Peer (logs) {
         states[k] = logs[k].length
 
     var stream = Stream(
-      states,
       function get (id, seq, cb) {
         cb(null, logs[id][seq - 1])
       },
@@ -31,10 +30,12 @@ function Peer (logs) {
           cb()
         }
         else cb(new Error('could not append'))
+      }
+    ) ({
+        seqs: states,
+        onChange: console.log,
       },
-      console.log,
-      cb
-    )
+      cb)
 
     logs._append.push(stream.onAppend)
 
@@ -216,4 +217,7 @@ tape('sink errors', function (t) {
     })
 
 })
+
+
+
 


### PR DESCRIPTION
With this change, instead of passing in an initial vector clock of everyone you want to replicate, you call a method. Also, you can pass the stream an `onRequest` function that gets called if the remote peer wants to replicate something you arn't replicating yet.
use `stream.request(id, -1)` if you do not want to replicate that.

The change enables @clehner's request skipping