### PR TITLE
Fix crash in EBTStream.canSend

### DIFF
--- a/stream.js
+++ b/stream.js
@@ -79,9 +79,10 @@ EBTStream.prototype.abort = EBTStream.prototype.end = function (err) {
 EBTStream.prototype.canSend = function () {
   var state = this.peer.state.peers[this.remote]
   return (
+    state &&
     this.sink &&
     !this.sink.paused && (
-      state.msgs.length || state.notes
+      (state.msgs && state.msgs.length) || state.notes
     )
   )
 }


### PR DESCRIPTION
Fixes #17 
Not sure if this is the right answer, but it does prevent the crash from happening any more.